### PR TITLE
Simple MQTT fix

### DIFF
--- a/nlp/dispatch.py
+++ b/nlp/dispatch.py
@@ -68,7 +68,7 @@ url_str = os.environ.get('AIRAMQTT_URL', 'preprod-mqtt.aira.io')
 port = int(os.environ.get('AIRAMQTT_PORT', '1883'))
 
 
-mqttc.connect(url_str, port, 60)
+mqttc.connect(url_str, port, 15)
 mqttc.subscribe(EXPLORER_SUB_TOPIC, 0)
 
 


### PR DESCRIPTION
Changed 1 variable for this. Essentially checks health every 15 seconds and timeout on server is 60 by default. Keeps extending it. Before was 60 seconds and timeout on server was 60 seconds so no communication happened causing the MQTT error to be thrown.